### PR TITLE
Fix the db connection parameter names - tickets/INSTRM-2644

### DIFF
--- a/config/actors/actors.yaml
+++ b/config/actors/actors.yaml
@@ -18,15 +18,15 @@ logging:
 
 db:
   opdb:
-    hostname: db-ics
+    host: db-ics
     dbname: opdb
     port: 5432
-    username: pfs
+    user: pfs
   gaia:
-    hostname: g2db.sum.subaru.nao.ac.jp
+    host: g2db.sum.subaru.nao.ac.jp
     dbname: star_catalog
     port: 5438
-    username: obsuser
+    user: obsuser
 
 misc:
   runInReactorThread: False


### PR DESCRIPTION
This is a fix for #44, changing `hostname` -> `host` and `username` -> `user`.

Some of the old db connection routines are using `hostname` and `username`, so the backwards compatibility of these names will go into the new db accessors in `ics_utils`. 